### PR TITLE
Fixed null-inviter bug

### DIFF
--- a/graph/resolver/participant.resolvers.go
+++ b/graph/resolver/participant.resolvers.go
@@ -92,7 +92,14 @@ func (r *participantResolver) Inviter(ctx context.Context, obj *model.Participan
 			return nil, fmt.Errorf("Could not retrieve discussion's moderator")
 		}
 
-		return inviter.NonAnon, nil
+		if inviter.NonAnon != nil {
+			return inviter.NonAnon, nil
+		} else if inviter.Anon != nil {
+			return inviter.Anon, nil
+		}
+
+		// We have a problem here
+		return nil, nil
 	}
 
 	inviter, err := r.DAOManager.GetParticipantByID(ctx, *obj.InviterID)


### PR DESCRIPTION
This fixes a minor bug present in #69 that prevented the resolver to return a non-null Inviter in some discussions.