### PR TITLE
Refactoring of Discussion subscription

### DIFF
--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -13,6 +13,10 @@ type DiscussionNotificationPreferences interface {
 	IsDiscussionNotificationPreferences()
 }
 
+type DiscussionSubscriptionEntity interface {
+	IsDiscussionSubscriptionEntity()
+}
+
 type Entity interface {
 	IsEntity()
 }
@@ -43,6 +47,11 @@ type DiscussionInput struct {
 	IdleMinutes   *int           `json:"idleMinutes"`
 	PublicAccess  *bool          `json:"publicAccess"`
 	IconURL       *string        `json:"iconURL"`
+}
+
+type DiscussionSubscriptionEvent struct {
+	EventType DiscussionSubscriptionEventType `json:"eventType"`
+	Entity    DiscussionSubscriptionEntity    `json:"entity"`
 }
 
 type Media struct {
@@ -159,6 +168,49 @@ func (e *AnonymityType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e AnonymityType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type DiscussionSubscriptionEventType string
+
+const (
+	DiscussionSubscriptionEventTypePostAdded         DiscussionSubscriptionEventType = "POST_ADDED"
+	DiscussionSubscriptionEventTypePostDeleted       DiscussionSubscriptionEventType = "POST_DELETED"
+	DiscussionSubscriptionEventTypeParticipantBanned DiscussionSubscriptionEventType = "PARTICIPANT_BANNED"
+)
+
+var AllDiscussionSubscriptionEventType = []DiscussionSubscriptionEventType{
+	DiscussionSubscriptionEventTypePostAdded,
+	DiscussionSubscriptionEventTypePostDeleted,
+	DiscussionSubscriptionEventTypeParticipantBanned,
+}
+
+func (e DiscussionSubscriptionEventType) IsValid() bool {
+	switch e {
+	case DiscussionSubscriptionEventTypePostAdded, DiscussionSubscriptionEventTypePostDeleted, DiscussionSubscriptionEventTypeParticipantBanned:
+		return true
+	}
+	return false
+}
+
+func (e DiscussionSubscriptionEventType) String() string {
+	return string(e)
+}
+
+func (e *DiscussionSubscriptionEventType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = DiscussionSubscriptionEventType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid DiscussionSubscriptionEventType", str)
+	}
+	return nil
+}
+
+func (e DiscussionSubscriptionEventType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/graph/model/participant.go
+++ b/graph/model/participant.go
@@ -4,6 +4,7 @@ import "time"
 
 type Participant struct {
 	Entity
+	DiscussionSubscriptionEntity
 	ID            string           `json:"id" gorm:"type:varchar(36);"`
 	ParticipantID int              `json:"participantID" dynamodbav:"ParticipantID"`
 	CreatedAt     time.Time        `json:"createdAt" gorm:"not null;default:CURRENT_TIMESTAMP;"`

--- a/graph/model/post.go
+++ b/graph/model/post.go
@@ -26,6 +26,7 @@ type AppActionID string
 type MutationID string
 
 type Post struct {
+	DiscussionSubscriptionEntity
 	ID                string             `json:"id" dynamodbav:"ID" gorm:"type:varchar(36);"`
 	PostType          PostType           `json:"postType"`
 	CreatedAt         time.Time          `json:"createdAt" gorm:"not null;default:CURRENT_TIMESTAMP;"`

--- a/graph/resolver/schema.resolvers.go
+++ b/graph/resolver/schema.resolvers.go
@@ -707,13 +707,3 @@ func (r *Resolver) Subscription() generated.SubscriptionResolver { return &subsc
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *subscriptionResolver) NewDiscussionEvent(ctx context.Context, discussionID string) (<-chan *model.DiscussionSubscriptionEvent, error) {
-	panic(fmt.Errorf("not implemented"))
-}

--- a/graph/types/discussion_subscription.graphqls
+++ b/graph/types/discussion_subscription.graphqls
@@ -1,0 +1,14 @@
+interface DiscussionSubscriptionEntity {
+    id: ID!
+}
+
+enum DiscussionSubscriptionEventType {
+    POST_ADDED,
+    POST_DELETED,
+    PARTICIPANT_BANNED
+}
+
+type DiscussionSubscriptionEvent {
+    eventType: DiscussionSubscriptionEventType!
+    entity: DiscussionSubscriptionEntity!
+}

--- a/graph/types/participant.graphqls
+++ b/graph/types/participant.graphqls
@@ -1,4 +1,4 @@
-type Participant implements Entity{
+type Participant implements Entity & DiscussionSubscriptionEntity {
     # The UUID for this participant.
     id: ID!
     # Fetching a participant directly is okay because we have no link back to who the user is.

--- a/graph/types/post.graphqls
+++ b/graph/types/post.graphqls
@@ -1,4 +1,4 @@
-type Post{
+type Post implements DiscussionSubscriptionEntity {
     id: ID!
     isDeleted: Boolean!
     deletedReasonCode: PostDeletedReason

--- a/graph/types/schema.graphqls
+++ b/graph/types/schema.graphqls
@@ -115,4 +115,5 @@ type Mutation {
 
 type Subscription {
   postAdded(discussionID: String!): Post
+  onDiscussionEvent(discussionID: String!): DiscussionSubscriptionEvent
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -26,6 +26,8 @@ type DelphisBackend interface {
 	GetDiscussionByModeratorID(ctx context.Context, moderatorID string) (*model.Discussion, error)
 	SubscribeToDiscussion(ctx context.Context, subscriberUserID string, postChannel chan *model.Post, discussionID string) error
 	UnSubscribeFromDiscussion(ctx context.Context, subscriberUserID string, discussionID string) error
+	SubscribeToDiscussionEvent(ctx context.Context, subscriberUserID string, eventChannel chan *model.DiscussionSubscriptionEvent, discussionID string) error
+	UnSubscribeFromDiscussionEvent(ctx context.Context, subscriberUserID string, discussionID string) error
 	ListDiscussions(ctx context.Context) (*model.DiscussionsConnection, error)
 	GetModeratorByID(ctx context.Context, id string) (*model.Moderator, error)
 	GetModeratorByUserID(ctx context.Context, userID string) (*model.Moderator, error)
@@ -55,6 +57,8 @@ type DelphisBackend interface {
 	PostImportedContent(ctx context.Context, participantID, discussionID, contentID string, postedAt *time.Time, matchingTags []string, dripType model.DripPostType) (*model.Post, error)
 	PutImportedContentQueue(ctx context.Context, discussionID, contentID string, postedAt *time.Time, matchingTags []string, dripType model.DripPostType) (*model.ContentQueueRecord, error)
 	NotifySubscribersOfCreatedPost(ctx context.Context, post *model.Post, discussionID string) error
+	NotifySubscribersOfDeletedPost(ctx context.Context, post *model.Post, discussionID string) error
+	NotifySubscribersOfBannedParticipant(ctx context.Context, participant *model.Participant, discussionID string) error
 	GetPostsConnectionByDiscussionID(ctx context.Context, discussionID string, cursor string, limit int) (*model.PostsConnection, error)
 	GetPostsByDiscussionID(ctx context.Context, userID string, discussionID string) ([]*model.Post, error)
 	GetLastPostByDiscussionID(ctx context.Context, discussionID string, minutes int) (*model.Post, error)


### PR DESCRIPTION
This refactor the socket-based subscription in each discussion by adding support to many kinds of events each user needs to be notified as soon as possible. As for now, those include post creation, post deletion, participant ban. The old GraphQL subscription, which only supported post creation events, has been maintained to not break old code support.