### PR TITLE
Discussion list personalized for each user

### DIFF
--- a/graph/resolver/schema.resolvers.go
+++ b/graph/resolver/schema.resolvers.go
@@ -601,7 +601,12 @@ func (r *queryResolver) Discussion(ctx context.Context, id string) (*model.Discu
 }
 
 func (r *queryResolver) ListDiscussions(ctx context.Context) ([]*model.Discussion, error) {
-	connection, err := r.DAOManager.ListDiscussions(ctx)
+	authedUser := auth.GetAuthedUser(ctx)
+	if authedUser == nil {
+		return nil, fmt.Errorf("Need auth")
+	}
+
+	connection, err := r.DAOManager.ListDiscussionsByUserID(ctx, authedUser.UserID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -29,6 +29,7 @@ type DelphisBackend interface {
 	SubscribeToDiscussionEvent(ctx context.Context, subscriberUserID string, eventChannel chan *model.DiscussionSubscriptionEvent, discussionID string) error
 	UnSubscribeFromDiscussionEvent(ctx context.Context, subscriberUserID string, discussionID string) error
 	ListDiscussions(ctx context.Context) (*model.DiscussionsConnection, error)
+	ListDiscussionsByUserID(ctx context.Context, userID string) (*model.DiscussionsConnection, error)
 	GetModeratorByID(ctx context.Context, id string) (*model.Moderator, error)
 	GetModeratorByUserID(ctx context.Context, userID string) (*model.Moderator, error)
 	CheckIfModerator(ctx context.Context, userID string) (bool, error)

--- a/internal/backend/discussion.go
+++ b/internal/backend/discussion.go
@@ -91,6 +91,10 @@ func (d *delphisBackend) ListDiscussions(ctx context.Context) (*model.Discussion
 	return d.db.ListDiscussions(ctx)
 }
 
+func (d *delphisBackend) ListDiscussionsByUserID(ctx context.Context, userID string) (*model.DiscussionsConnection, error) {
+	return d.db.ListDiscussionsByUserID(ctx, userID)
+}
+
 func (d *delphisBackend) SubscribeToDiscussion(ctx context.Context, subscriberUserID string, postChannel chan *model.Post, discussionID string) error {
 	cacheKey := fmt.Sprintf(discussionSubscriberKey, discussionID)
 	d.discussionMutex.Lock()

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -31,6 +31,7 @@ type Datastore interface {
 	GetModeratorByUserID(ctx context.Context, id string) (*model.Moderator, error)
 	GetModeratorByUserIDAndDiscussionID(ctx context.Context, userID, discussionID string) (*model.Moderator, error)
 	ListDiscussions(ctx context.Context) (*model.DiscussionsConnection, error)
+	ListDiscussionsByUserID(ctx context.Context, userID string) (*model.DiscussionsConnection, error)
 	UpsertDiscussion(ctx context.Context, discussion model.Discussion) (*model.Discussion, error)
 	AssignFlair(ctx context.Context, participant model.Participant, flairID *string) (*model.Participant, error)
 	GetFlairByID(ctx context.Context, id string) (*model.Flair, error)

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -1345,6 +1345,29 @@ func (_m *Datastore) ListDiscussions(ctx context.Context) (*model.DiscussionsCon
 	return r0, r1
 }
 
+// ListDiscussionsByUserID provides a mock function with given fields: ctx, userID
+func (_m *Datastore) ListDiscussionsByUserID(ctx context.Context, userID string) (*model.DiscussionsConnection, error) {
+	ret := _m.Called(ctx, userID)
+
+	var r0 *model.DiscussionsConnection
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.DiscussionsConnection); ok {
+		r0 = rf(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.DiscussionsConnection)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListFlairTemplates provides a mock function with given fields: ctx, query
 func (_m *Datastore) ListFlairTemplates(ctx context.Context, query *string) ([]*model.FlairTemplate, error) {
 	ret := _m.Called(ctx, query)


### PR DESCRIPTION
This addresses #60.`listDiscussions` query now returns a list of discussion personalized for each user. Users will now be able to see only:
- Discussion of which they are moderators
- Discussions of which they are participants
- Discussions to which they are invited, either by flair invitation or personal invitation

The discussions in the list are ordered by priority using the same order of the list above. Discussions with equal priority are ordered by most recent post date.
NOTE: Discussions joinable by link will appear in the feed only once the user has joined them.