### PR TITLE
CHAT-110 Fix

### DIFF
--- a/graph/resolver/discussion.resolvers.go
+++ b/graph/resolver/discussion.resolvers.go
@@ -202,6 +202,9 @@ func (r *discussionResolver) MeNotificationSettings(ctx context.Context, obj *mo
 	if err != nil {
 		return nil, fmt.Errorf("Error fetching user information")
 	}
+	if resp == nil {
+		return nil, nil
+	}
 
 	return &resp.NotifSetting, nil
 }


### PR DESCRIPTION
ADDRESSES CHAT-110

Solves the bug that prevented a non-joined user from fetching the `meNotificationSettings` field of a Discussion. This was blocking for a flawless join-flow when opening the discussion from an external link.