### PR TITLE
MeDiscussionStatus null-ptr exception

### DIFF
--- a/graph/resolver/discussion.resolvers.go
+++ b/graph/resolver/discussion.resolvers.go
@@ -219,7 +219,9 @@ func (r *discussionResolver) MeDiscussionStatus(ctx context.Context, obj *model.
 	if err != nil {
 		return nil, fmt.Errorf("Error fetching user information")
 	}
-
+	if resp == nil {
+		return nil, nil
+	}
 	return &resp.State, nil
 }
 


### PR DESCRIPTION
A null-ptr exception is thrown by fetching `Discussion.meDiscussionStatus` if the user hasn't joined the discussion yet. The proper behavior should be to simply return null on that field instead. This PR addresses this little fix.