### PR TITLE
Backend 1 pointers

### DIFF
--- a/graph/resolver/schema.resolvers.go
+++ b/graph/resolver/schema.resolvers.go
@@ -26,6 +26,14 @@ func (r *mutationResolver) AddDiscussionParticipant(ctx context.Context, discuss
 		if err != nil || !modCheck {
 			return nil, fmt.Errorf("unauthorized")
 		}
+
+		if discussionParticipantInput.IsAnonymous == true {
+			return nil, fmt.Errorf("mods cannot create anonymous participants")
+		}
+	} else {
+		if discussionParticipantInput.IsAnonymous == false {
+			return nil, fmt.Errorf("participants must be anonymous")
+		}
 	}
 
 	existingParticipants, err := r.DAOManager.GetParticipantsByDiscussionIDUserID(ctx, discussionID, userID)

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -53,7 +53,7 @@ type DelphisBackend interface {
 	MuteParticipants(ctx context.Context, discussionID string, participantIDs []string, muteForSeconds int) ([]*model.Participant, error)
 	UnmuteParticipants(ctx context.Context, discussionID string, participantIDs []string) ([]*model.Participant, error)
 	CreatePost(ctx context.Context, discussionID string, userID string, participantID string, input model.PostContentInput) (*model.Post, error)
-	CreateAlertPost(ctx context.Context, discussionID string, userObj *model.User, isAnonymous bool) (*model.Post, error)
+	CreateAlertPost(ctx context.Context, discussionID string, participantID string, userObj *model.User, isAnonymous bool) (*model.Post, error)
 	NotifySubscribersOfCreatedPost(ctx context.Context, post *model.Post, discussionID string) error
 	NotifySubscribersOfDeletedPost(ctx context.Context, post *model.Post, discussionID string) error
 	NotifySubscribersOfBannedParticipant(ctx context.Context, participant *model.Participant, discussionID string) error

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -38,6 +38,7 @@ type DelphisBackend interface {
 	ListDiscussionsByUserID(ctx context.Context, userID string, state model.DiscussionUserAccessState) (*model.DiscussionsConnection, error)
 	GetModeratorByID(ctx context.Context, id string) (*model.Moderator, error)
 	GetModeratorByUserID(ctx context.Context, userID string) (*model.Moderator, error)
+	GetModeratorByDiscussionID(ctx context.Context, discussionID string) (*model.Moderator, error)
 	GetModeratedDiscussionsByUserID(ctx context.Context, userID string) ([]*model.Discussion, error)
 	CheckIfModerator(ctx context.Context, userID string) (bool, error)
 	CheckIfModeratorForDiscussion(ctx context.Context, userID string, discussionID string) (bool, error)

--- a/internal/backend/discussion.go
+++ b/internal/backend/discussion.go
@@ -168,6 +168,15 @@ func (d *delphisBackend) GetDiscussionJoinabilityForUser(ctx context.Context, us
 
 	if discussionObj.DiscussionJoinability == model.DiscussionJoinabilitySettingAllowTwitterFriends {
 		// Now we need to know if this moderator follows the user on Twitter.
+		if discussionObj.Moderator == nil {
+			modObj, err := d.GetModeratorByDiscussionID(ctx, discussionObj.ID)
+			if err != nil {
+				logrus.WithError(err).Error("failed to get moderator by discussionID")
+				return nil, err
+			}
+
+			discussionObj.Moderator = modObj
+		}
 		moderatorSocialInfos, err := d.GetSocialInfosByUserProfileID(ctx, *discussionObj.Moderator.UserProfileID)
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching moderator information")

--- a/internal/backend/moderator.go
+++ b/internal/backend/moderator.go
@@ -16,6 +16,10 @@ func (d *delphisBackend) GetModeratorByUserID(ctx context.Context, userID string
 	return d.db.GetModeratorByUserID(ctx, userID)
 }
 
+func (d *delphisBackend) GetModeratorByDiscussionID(ctx context.Context, discussionID string) (*model.Moderator, error) {
+	return d.db.GetModeratorByDiscussionID(ctx, discussionID)
+}
+
 func (d *delphisBackend) GetModeratorByUserIDAndDiscussionID(ctx context.Context, userID, discussionID string) (*model.Moderator, error) {
 	return d.db.GetModeratorByUserIDAndDiscussionID(ctx, userID, discussionID)
 }

--- a/internal/backend/participant.go
+++ b/internal/backend/participant.go
@@ -67,7 +67,7 @@ func (d *delphisBackend) CreateParticipantForDiscussion(ctx context.Context, dis
 		return nil, err
 	}
 
-	if _, err := d.CreateAlertPost(ctx, discussionID, userObj, discussionParticipantInput.IsAnonymous); err != nil {
+	if _, err := d.CreateAlertPost(ctx, discussionID, participantObj.ID, userObj, discussionParticipantInput.IsAnonymous); err != nil {
 		// Don't return err. Just log
 		logrus.WithError(err).Error("failed to create alert post")
 	}

--- a/internal/backend/participant_test.go
+++ b/internal/backend/participant_test.go
@@ -108,6 +108,7 @@ func TestDelphisBackend_CreateParticipantForDiscussion(t *testing.T) {
 			mockDB.On("UpsertParticipant", ctx, mock.Anything).Return(&parObj, nil)
 
 			//// Create post functions
+			mockDB.On("GetDiscussionByID", ctx, discussionID).Return(&discObj, nil)
 			mockDB.On("GetParticipantsByDiscussionIDUserID", ctx, mock.Anything, mock.Anything).Return([]model.Participant{parObj}, nil)
 			mockDB.On("BeginTx", ctx).Return(nil, expectedError)
 
@@ -125,6 +126,7 @@ func TestDelphisBackend_CreateParticipantForDiscussion(t *testing.T) {
 			mockDB.On("UpsertParticipant", ctx, mock.Anything).Return(&parObj, nil)
 
 			//// Create post functions
+			mockDB.On("GetDiscussionByID", ctx, discussionID).Return(&discObj, nil)
 			mockDB.On("GetParticipantsByDiscussionIDUserID", ctx, mock.Anything, mock.Anything).Return([]model.Participant{parObj}, nil)
 			mockDB.On("BeginTx", ctx).Return(&tx, nil)
 			mockDB.On("PutPostContent", ctx, mock.Anything, mock.Anything).Return(nil)

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -29,6 +29,7 @@ type Datastore interface {
 	CreateModerator(ctx context.Context, moderator model.Moderator) (*model.Moderator, error)
 	GetModeratorByID(ctx context.Context, id string) (*model.Moderator, error)
 	GetModeratorByUserID(ctx context.Context, id string) (*model.Moderator, error)
+	GetModeratorByDiscussionID(ctx context.Context, discussionID string) (*model.Moderator, error)
 	GetModeratorByUserIDAndDiscussionID(ctx context.Context, userID, discussionID string) (*model.Moderator, error)
 	GetModeratedDiscussionsByUserID(ctx context.Context, userID string) DiscussionIter
 	ListDiscussions(ctx context.Context) (*model.DiscussionsConnection, error)
@@ -276,6 +277,10 @@ func (d *delphisDB) initializeStatements(ctx context.Context) (err error) {
 	if d.prepStmts.getModeratorByUserIDStmt, err = d.pg.PrepareContext(ctx, getModeratorByUserIDString); err != nil {
 		logrus.WithError(err).Error("failed to prepare getModeratorByUserProfileID")
 		return errors.Wrap(err, "failed to prepare getModeratorByUserProfileID")
+	}
+	if d.prepStmts.getModeratorByDiscussionIDStmt, err = d.pg.PrepareContext(ctx, getModeratorByDiscussionIDString); err != nil {
+		logrus.WithError(err).Error("failed to prepare getModeratorByDiscussionIDStmt")
+		return errors.Wrap(err, "failed to prepare getModeratorByDiscussionIDStmt")
 	}
 	if d.prepStmts.getModeratorByUserIDAndDiscussionIDStmt, err = d.pg.PrepareContext(ctx, getModeratorByUserIDAndDiscussionIDString); err != nil {
 		logrus.WithError(err).Error("failed to prepare getModeratorByUserIDAndDiscussionIDStmt")

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -108,6 +108,10 @@ func TestDelphisDB_InitializeStatements(t *testing.T) {
 				Test: getModeratorByUserIDString,
 			},
 			{
+				Name: "getModeratorByDiscussionIDString",
+				Test: getModeratorByDiscussionIDString,
+			},
+			{
 				Name: "getModeratorByUserIDAndDiscussionIDString",
 				Test: getModeratorByUserIDAndDiscussionIDString,
 			},

--- a/internal/datastore/moderator.go
+++ b/internal/datastore/moderator.go
@@ -50,6 +50,34 @@ func (d *delphisDB) GetModeratorByUserID(ctx context.Context, id string) (*model
 	return &moderator, nil
 }
 
+func (d *delphisDB) GetModeratorByDiscussionID(ctx context.Context, discussionID string) (*model.Moderator, error) {
+	logrus.Debug("GetModeratorByDiscussionID::SQL Query")
+	if err := d.initializeStatements(ctx); err != nil {
+		logrus.WithError(err).Error("GetModeratorByDiscussionID failed to initialize statements")
+		return nil, err
+	}
+
+	moderator := model.Moderator{}
+	if err := d.prepStmts.getModeratorByDiscussionIDStmt.QueryRowContext(
+		ctx,
+		discussionID,
+	).Scan(
+		&moderator.ID,
+		&moderator.CreatedAt,
+		&moderator.UpdatedAt,
+		&moderator.DeletedAt,
+		&moderator.UserProfileID,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		logrus.WithError(err).Error("failed to execute getModeratorByDiscussionIDStmt")
+		return nil, err
+	}
+
+	return &moderator, nil
+}
+
 func (d *delphisDB) GetModeratorByUserIDAndDiscussionID(ctx context.Context, userID, discussionID string) (*model.Moderator, error) {
 	logrus.Debug("GetModeratorByUserIDAndDiscussionID::SQL Query")
 	if err := d.initializeStatements(ctx); err != nil {

--- a/internal/datastore/prepared_statements.go
+++ b/internal/datastore/prepared_statements.go
@@ -451,6 +451,7 @@ const getDiscussionAccessRequestsString = `
 			status
 		FROM discussion_user_requests
 		WHERE discussion_id = $1
+			AND status = 'PENDING'
 			AND deleted_at is null;`
 
 const getDiscussionAccessRequestByUserIDString = `

--- a/internal/datastore/prepared_statements.go
+++ b/internal/datastore/prepared_statements.go
@@ -32,6 +32,7 @@ type dbPrepStmts struct {
 
 	// Moderator
 	getModeratorByUserIDStmt                *sql2.Stmt
+	getModeratorByDiscussionIDStmt          *sql2.Stmt
 	getModeratorByUserIDAndDiscussionIDStmt *sql2.Stmt
 	getModeratedDiscussionsByUserIDStmt     *sql2.Stmt
 
@@ -288,6 +289,18 @@ const getModeratorByUserIDString = `
 		INNER JOIN discussions d
 		ON m.id = d.moderator_id
 		WHERE u.user_id = $1 LIMIT 1;`
+
+const getModeratorByDiscussionIDString = `
+		SELECT m.id,
+			m.created_at,
+			m.updated_at,
+			m.deleted_at,
+			m.user_profile_id
+		FROM moderators m
+		INNER JOIN discussions d
+		ON m.id = d.moderator_id
+		WHERE d.id = $1;
+`
 
 const getModeratorByUserIDAndDiscussionIDString = `
 		SELECT m.id,

--- a/internal/datastore/test_setup.go
+++ b/internal/datastore/test_setup.go
@@ -23,6 +23,7 @@ func mockPreparedStatements(mock sqlmock.Sqlmock) {
 	mock.ExpectPrepare(getDiscussionArchiveByDiscussionIDString)
 	mock.ExpectPrepare(upsertDiscussionArchiveString)
 	mock.ExpectPrepare(getModeratorByUserIDString)
+	mock.ExpectPrepare(getModeratorByDiscussionIDString)
 	mock.ExpectPrepare(getModeratorByUserIDAndDiscussionIDString)
 	mock.ExpectPrepare(getModeratedDiscussionsByUserIDString)
 	mock.ExpectPrepare(getDiscussionsByUserAccessString)

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -648,6 +648,29 @@ func (_m *Datastore) GetModeratedDiscussionsByUserID(ctx context.Context, userID
 	return r0
 }
 
+// GetModeratorByDiscussionID provides a mock function with given fields: ctx, discussionID
+func (_m *Datastore) GetModeratorByDiscussionID(ctx context.Context, discussionID string) (*model.Moderator, error) {
+	ret := _m.Called(ctx, discussionID)
+
+	var r0 *model.Moderator
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.Moderator); ok {
+		r0 = rf(ctx, discussionID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Moderator)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, discussionID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetModeratorByID provides a mock function with given fields: ctx, id
 func (_m *Datastore) GetModeratorByID(ctx context.Context, id string) (*model.Moderator, error) {
 	ret := _m.Called(ctx, id)


### PR DESCRIPTION
- Change the anonymous display name to use the display name function
- When joining an {archived, deleted} discussion, ensure it's moved to active tab
- Block participants from creating non-anon participants and the mod from creating a anon participant
- Do not return discussion requests if they have been approved or rejected
- If Moderator is null on discussion object it throws an exception