### PR TITLE
Locked discussion

### DIFF
--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -1960,7 +1960,8 @@ enum DiscussionJoinabilityResponse {
 enum DiscussionUserAccessState {
     ACTIVE,
     ARCHIVED,
-    DELETED
+    DELETED,
+    BANNED
 }
 
 enum DiscussionUserNotificationSetting {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -270,17 +270,19 @@ const (
 	DiscussionUserAccessStateActive   DiscussionUserAccessState = "ACTIVE"
 	DiscussionUserAccessStateArchived DiscussionUserAccessState = "ARCHIVED"
 	DiscussionUserAccessStateDeleted  DiscussionUserAccessState = "DELETED"
+	DiscussionUserAccessStateBanned   DiscussionUserAccessState = "BANNED"
 )
 
 var AllDiscussionUserAccessState = []DiscussionUserAccessState{
 	DiscussionUserAccessStateActive,
 	DiscussionUserAccessStateArchived,
 	DiscussionUserAccessStateDeleted,
+	DiscussionUserAccessStateBanned,
 }
 
 func (e DiscussionUserAccessState) IsValid() bool {
 	switch e {
-	case DiscussionUserAccessStateActive, DiscussionUserAccessStateArchived, DiscussionUserAccessStateDeleted:
+	case DiscussionUserAccessStateActive, DiscussionUserAccessStateArchived, DiscussionUserAccessStateDeleted, DiscussionUserAccessStateBanned:
 		return true
 	}
 	return false

--- a/graph/resolver/schema.resolvers.go
+++ b/graph/resolver/schema.resolvers.go
@@ -179,6 +179,12 @@ func (r *mutationResolver) UpdateParticipant(ctx context.Context, discussionID s
 		return nil, fmt.Errorf("Need auth")
 	}
 
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
+	}
+
 	participantResponse, err := r.DAOManager.GetParticipantsByDiscussionIDUserID(ctx, discussionID, authedUser.UserID)
 	if err != nil {
 		return nil, err
@@ -239,6 +245,12 @@ func (r *mutationResolver) UpdateDiscussion(ctx context.Context, discussionID st
 		return nil, fmt.Errorf("unauthorized")
 	}
 
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
+	}
+
 	return r.DAOManager.UpdateDiscussion(ctx, discussionID, input)
 }
 
@@ -248,6 +260,12 @@ func (r *mutationResolver) UpdateDiscussionUserSettings(ctx context.Context, dis
 		return nil, fmt.Errorf("Need auth")
 	}
 
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
+	}
+
 	return r.DAOManager.UpsertUserDiscussionAccess(ctx, authedUser.UserID, discussionID, settings)
 }
 
@@ -255,6 +273,12 @@ func (r *mutationResolver) RequestAccessToDiscussion(ctx context.Context, discus
 	authedUser := auth.GetAuthedUser(ctx)
 	if authedUser == nil {
 		return nil, fmt.Errorf("Need auth")
+	}
+
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
 	}
 
 	return r.DAOManager.RequestAccessToDiscussion(ctx, authedUser.UserID, discussionID)
@@ -303,6 +327,12 @@ func (r *mutationResolver) DeletePost(ctx context.Context, discussionID string, 
 		return nil, fmt.Errorf("Need auth")
 	}
 
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
+	}
+
 	deletedPost, err := r.DAOManager.DeletePostByID(ctx, discussionID, postID, authedUser.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to delete post")
@@ -323,6 +353,12 @@ func (r *mutationResolver) BanParticipant(ctx context.Context, discussionID stri
 		return nil, fmt.Errorf("Need auth")
 	}
 
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
+	}
+
 	bannedParticipant, err := r.DAOManager.BanParticipant(ctx, discussionID, participantID, authedUser.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to ban participant")
@@ -341,6 +377,12 @@ func (r *mutationResolver) ShuffleDiscussion(ctx context.Context, discussionID s
 	authedUser := auth.GetAuthedUser(ctx)
 	if authedUser == nil {
 		return nil, fmt.Errorf("Need auth")
+	}
+
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
 	}
 
 	modCheck, err := r.DAOManager.CheckIfModeratorForDiscussion(ctx, authedUser.UserID, discussionID)
@@ -398,6 +440,12 @@ func (r *mutationResolver) MuteParticipants(ctx context.Context, discussionID st
 		return nil, fmt.Errorf("Need auth")
 	}
 
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
+	}
+
 	if mutedForSeconds < 0 || mutedForSeconds > 86400 {
 		return nil, fmt.Errorf("mutedForSeconds value is invalid")
 	}
@@ -415,6 +463,12 @@ func (r *mutationResolver) UnmuteParticipants(ctx context.Context, discussionID 
 	authedUser := auth.GetAuthedUser(ctx)
 	if authedUser == nil {
 		return nil, fmt.Errorf("Need auth")
+	}
+
+	// Note: This is here mainly to ensure the discussion is not (soft) deleted
+	discussion, err := r.DAOManager.GetDiscussionByID(ctx, discussionID)
+	if discussion == nil || err != nil || discussion.LockStatus == true {
+		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
 	}
 
 	/* Only moderators can use this mutation */

--- a/graph/resolver/schema.resolvers.go
+++ b/graph/resolver/schema.resolvers.go
@@ -281,7 +281,15 @@ func (r *mutationResolver) RequestAccessToDiscussion(ctx context.Context, discus
 		return nil, fmt.Errorf("Discussion with ID %s not found", discussionID)
 	}
 
-	return r.DAOManager.RequestAccessToDiscussion(ctx, authedUser.UserID, discussionID)
+	resp, err := r.DAOManager.RequestAccessToDiscussion(ctx, authedUser.UserID, discussionID)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("user already has access to discussion")
+	}
+
+	return resp, nil
 }
 
 func (r *mutationResolver) RespondToRequestAccess(ctx context.Context, requestID string, response model.InviteRequestStatus) (*model.DiscussionAccessRequest, error) {

--- a/graph/resolver/schema.resolvers.go
+++ b/graph/resolver/schema.resolvers.go
@@ -128,7 +128,7 @@ func (r *mutationResolver) AddPost(ctx context.Context, discussionID string, par
 	}
 
 	// Verify that the posting participant belongs to the logged-in user
-	if *participant.UserID != authedUser.UserID {
+	if *participant.UserID != authedUser.UserID || *participant.DiscussionID != discussionID {
 		return nil, fmt.Errorf("Unauthorized")
 	}
 

--- a/graph/types/enums.graphqls
+++ b/graph/types/enums.graphqls
@@ -68,7 +68,8 @@ enum DiscussionJoinabilityResponse {
 enum DiscussionUserAccessState {
     ACTIVE,
     ARCHIVED,
-    DELETED
+    DELETED,
+    BANNED
 }
 
 enum DiscussionUserNotificationSetting {

--- a/internal/backend/invite_request.go
+++ b/internal/backend/invite_request.go
@@ -36,6 +36,18 @@ func (d *delphisBackend) RequestAccessToDiscussion(ctx context.Context, userID, 
 		Status:       model.InviteRequestStatusPending,
 	}
 
+	// Check if user already has access
+	dua, err := d.GetDiscussionUserAccess(ctx, discussionID, userID)
+	if err != nil {
+		logrus.WithError(err).Error("failed to get discussion user access")
+		return nil, err
+	}
+
+	if dua != nil && dua.State == model.DiscussionUserAccessStateActive {
+		logrus.Infof("user already has access ")
+		return nil, nil
+	}
+
 	// TODO: Should block users from spamming requests?
 	// Begin tx
 	tx, err := d.db.BeginTx(ctx)

--- a/internal/backend/invite_request_test.go
+++ b/internal/backend/invite_request_test.go
@@ -182,8 +182,19 @@ func TestDelphisBackend_RequestAccessToDiscussion(t *testing.T) {
 			timeProvider:    &util.FrozenTime{NowTime: now},
 		}
 
+		Convey("when GetDiscussionUserAccess errors out and RollbackFails", func() {
+			expectedError := fmt.Errorf("Some Error")
+			mockDB.On("GetDiscussionUserAccess", ctx, mock.Anything, mock.Anything).Return(nil, expectedError)
+
+			resp, err := backendObj.RequestAccessToDiscussion(ctx, userID, discussionID)
+
+			So(err, ShouldNotBeNil)
+			So(resp, ShouldBeNil)
+		})
+
 		Convey("when BeginTx errors out", func() {
 			expectedError := fmt.Errorf("Some Error")
+			mockDB.On("GetDiscussionUserAccess", ctx, mock.Anything, mock.Anything).Return(nil, nil)
 			mockDB.On("BeginTx", ctx).Return(nil, expectedError)
 
 			resp, err := backendObj.RequestAccessToDiscussion(ctx, userID, discussionID)
@@ -194,6 +205,7 @@ func TestDelphisBackend_RequestAccessToDiscussion(t *testing.T) {
 
 		Convey("when PutDiscussionAccessRequestRecord errors out and RollbackFails", func() {
 			expectedError := fmt.Errorf("Some Error")
+			mockDB.On("GetDiscussionUserAccess", ctx, mock.Anything, mock.Anything).Return(nil, nil)
 			mockDB.On("BeginTx", ctx).Return(&tx, nil)
 			mockDB.On("PutDiscussionAccessRequestRecord", ctx, mock.Anything, mock.Anything).Return(nil, expectedError)
 			mockDB.On("RollbackTx", ctx, mock.Anything).Return(expectedError)
@@ -206,6 +218,7 @@ func TestDelphisBackend_RequestAccessToDiscussion(t *testing.T) {
 
 		Convey("when PutDiscussionAccessRequestRecord errors out", func() {
 			expectedError := fmt.Errorf("Some Error")
+			mockDB.On("GetDiscussionUserAccess", ctx, mock.Anything, mock.Anything).Return(nil, nil)
 			mockDB.On("BeginTx", ctx).Return(&tx, nil)
 			mockDB.On("PutDiscussionAccessRequestRecord", ctx, mock.Anything, mock.Anything).Return(nil, expectedError)
 			mockDB.On("RollbackTx", ctx, mock.Anything).Return(nil)
@@ -218,6 +231,7 @@ func TestDelphisBackend_RequestAccessToDiscussion(t *testing.T) {
 
 		Convey("when CommitTx errors out", func() {
 			expectedError := fmt.Errorf("Some Error")
+			mockDB.On("GetDiscussionUserAccess", ctx, mock.Anything, mock.Anything).Return(nil, nil)
 			mockDB.On("BeginTx", ctx).Return(&tx, nil)
 			mockDB.On("PutDiscussionAccessRequestRecord", ctx, mock.Anything, mock.Anything).Return(&requestObj, nil)
 			mockDB.On("CommitTx", ctx, mock.Anything).Return(expectedError)
@@ -229,6 +243,7 @@ func TestDelphisBackend_RequestAccessToDiscussion(t *testing.T) {
 		})
 
 		Convey("when invite succeeds", func() {
+			mockDB.On("GetDiscussionUserAccess", ctx, mock.Anything, mock.Anything).Return(nil, nil)
 			mockDB.On("BeginTx", ctx).Return(&tx, nil)
 			mockDB.On("PutDiscussionAccessRequestRecord", ctx, mock.Anything, mock.Anything).Return(&requestObj, nil)
 			mockDB.On("CommitTx", ctx, mock.Anything).Return(nil)

--- a/internal/backend/participant.go
+++ b/internal/backend/participant.go
@@ -118,9 +118,17 @@ func (d *delphisBackend) BanParticipant(ctx context.Context, discussionID string
 
 	participantObj.IsBanned = true
 	updatedParticipant, err := d.db.UpsertParticipant(ctx, *participantObj)
-
 	if err != nil {
 		logrus.WithError(err).Error("Failed to update participant")
+		return nil, err
+	}
+
+	banned := model.DiscussionUserAccessStateBanned
+	settings := model.DiscussionUserSettings{
+		State: &banned,
+	}
+	if _, err := d.UpsertUserDiscussionAccess(ctx, *participantObj.UserID, discussionID, settings); err != nil {
+		logrus.WithError(err).Error("failed to upsert banned user discussion access")
 		return nil, err
 	}
 

--- a/internal/datastore/discussion.go
+++ b/internal/datastore/discussion.go
@@ -155,8 +155,6 @@ func (d *delphisDB) ListDiscussionsByUserID(ctx context.Context, userID string, 
 	//TODO: this should take in paging params and return based on those.
 	logrus.Debugf("ListDiscussions::SQL Query")
 
-	logrus.Infof("State: %+v\n", state)
-
 	iter := d.GetDiscussionsByUserAccess(ctx, userID, state)
 	discArr, err := d.DiscussionIterCollect(ctx, iter)
 	if err != nil {

--- a/internal/datastore/prepared_statements.go
+++ b/internal/datastore/prepared_statements.go
@@ -363,7 +363,6 @@ const getDiscussionsByUserAccessString = `
 			ON dua.discussion_id = d.id
 		WHERE dua.user_id = $1
 			AND dua.state = $2
-			AND d.lock_status = false
 			AND d.deleted_at is null
 		ORDER BY d.last_post_created_at desc;`
 


### PR DESCRIPTION
- Block locked discussions from being mutated
- Block users with access from requesting access
- Harden AddPost
- On ban, remove discussion user access, change listDiscussions
- Other odds and ends